### PR TITLE
Fix Deprecation function(load -> safe_load)

### DIFF
--- a/tests/integration/canary_test/util.py
+++ b/tests/integration/canary_test/util.py
@@ -133,5 +133,5 @@ def load_config(config, dir=''):
         os.path.dirname(os.path.abspath(__file__)) + dir, config
     )
     with open(config_file, "r") as f:
-        config = yaml.load(f)
+        config = yaml.safe_load(f)
     return config

--- a/tests/integration/util.py
+++ b/tests/integration/util.py
@@ -17,5 +17,5 @@ def load_config(config, dir=''):
         os.path.dirname(os.path.abspath(__file__)) + dir, config
     )
     with open(config_file, "r") as f:
-        config = yaml.load(f)
+        config = yaml.safe_load(f)
     return config

--- a/tools/deploy/cluster.py
+++ b/tools/deploy/cluster.py
@@ -75,7 +75,7 @@ class Cluster(object):
         """
         with open(cfg_file, 'r') as f:
             try:
-                cfg = yaml.load(f)
+                cfg = yaml.safe_load(f)
             except yaml.YAMLError as ex:
                 print 'Failed to unmarshal cluster config %s' % cfg_file
                 raise ex

--- a/tools/minicluster/main.py
+++ b/tools/minicluster/main.py
@@ -57,7 +57,7 @@ def load_config():
         os.path.dirname(os.path.abspath(__file__)), "config.yaml"
     )
     with open(config_file, "r") as f:
-        config = yaml.load(f)
+        config = yaml.safe_load(f)
     return config
 
 

--- a/tools/vcluster/config_generator.py
+++ b/tools/vcluster/config_generator.py
@@ -9,7 +9,7 @@ from peloton_client.pbgen.peloton.api.v0 import peloton_pb2 as peloton
 
 def load_config(config_file):
     with open(config_file, 'r') as f:
-        config = yaml.load(f)
+        config = yaml.safe_load(f)
     return config
 
 


### PR DESCRIPTION
Hi, I fixed to safe_load function from load function
Because, load function is deprecated.
detail: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

Please check this pull request.
Thank you.